### PR TITLE
Refactor simple data holders into records

### DIFF
--- a/svn_trunk/src/jd/plugins/download/HashInfo.java
+++ b/svn_trunk/src/jd/plugins/download/HashInfo.java
@@ -7,7 +7,7 @@ import org.appwork.utils.StringUtils;
 import org.appwork.utils.encoding.Base64;
 import org.appwork.utils.formatter.HexFormatter;
 
-public class HashInfo {
+public record HashInfo(String hash, TYPE type, boolean trustworthy, boolean forced) {
     public static enum TYPE {
         // order is important! see isStrongerThan/isWeakerThan
         SHA512("SHA-512", 128),
@@ -57,8 +57,6 @@ public class HashInfo {
         }
     }
 
-    private final String hash;
-
     public String getHash() {
         return hash;
     }
@@ -70,10 +68,6 @@ public class HashInfo {
     public boolean isNone() {
         return TYPE.NONE.equals(type);
     }
-
-    private final TYPE    type;
-    private final boolean trustworthy;
-    private final boolean forced;
 
     public boolean isTrustworthy() {
         return trustworthy;
@@ -152,14 +146,13 @@ public class HashInfo {
         return null;
     }
 
-    public HashInfo(final String hash, TYPE type, boolean trustworthy, boolean forced) {
+    public HashInfo {
         if (type == null) {
             throw new IllegalArgumentException("type is missing");
-        } else {
-            this.type = type;
         }
+        String calculatedHash;
         if (TYPE.NONE.equals(type)) {
-            this.hash = "";
+            calculatedHash = "";
         } else {
             final String hexHash;
             if (StringUtils.isEmpty(hash)) {
@@ -178,13 +171,15 @@ public class HashInfo {
             if (StringUtils.isEmpty(hexHash)) {
                 throw new IllegalArgumentException("hash is empty:" + type + "-" + hash);
             } else if (hexHash.length() < type.getSize()) {
-                this.hash = String.format("%0" + (type.getSize() - hexHash.length()) + "d%s", 0, hexHash);
+                calculatedHash = String.format("%0" + (type.getSize() - hexHash.length()) + "d%s", 0, hexHash);
             } else if (hexHash.length() > type.getSize()) {
                 throw new IllegalArgumentException("invalid hash size:" + type + "-" + hash);
             } else {
-                this.hash = hexHash.toLowerCase(Locale.ENGLISH);
+                calculatedHash = hexHash.toLowerCase(Locale.ENGLISH);
             }
         }
+        this.hash = calculatedHash;
+        this.type = type;
         this.trustworthy = trustworthy;
         this.forced = forced;
     }

--- a/svn_trunk/src/org/jdownloader/plugins/components/usenet/UsenetServer.java
+++ b/svn_trunk/src/org/jdownloader/plugins/components/usenet/UsenetServer.java
@@ -9,56 +9,36 @@ import org.appwork.utils.StringUtils;
 /**
  * Represents a Usenet server with host, port, and SSL configuration.
  */
-public class UsenetServer implements Storable {
-    private String  host        = null;
-    private int     port        = -1;
-    private int     connections = -1;
-    private boolean ssl         = false;
+public record UsenetServer(String host, int port, int connections, boolean ssl) implements Storable {
 
     public UsenetServer() {
-        // Required for Storable
+        this(null, -1, -1, false);
     }
 
     public UsenetServer(final String host, final int port) {
-        this(host, port, false);
+        this(host, port, -1, false);
     }
 
     public UsenetServer(final String host, final int port, final boolean ssl) {
-        this.host = host;
-        this.port = port;
-        this.ssl = ssl;
+        this(host, port, -1, ssl);
     }
 
     public String getHost() {
         return host;
     }
 
-    public void setHost(String host) {
-        this.host = host;
-    }
-
     public int getPort() {
         return port > 0 ? port : (isSSL() ? 563 : 119);
     }
 
-    public void setPort(int port) {
-        this.port = port;
-    }
 
     public boolean isSSL() {
         return ssl;
     }
 
-    public void setSSL(boolean ssl) {
-        this.ssl = ssl;
-    }
 
     public int getConnections() {
         return connections;
-    }
-
-    public void setConnections(int connections) {
-        this.connections = connections;
     }
 
     // Public Methods


### PR DESCRIPTION
## Summary
- replace the mutable `UsenetServer` class with a Java record
- convert `HashInfo` to use a Java record and compact constructor

## Testing
- `mvn -q test` *(fails: no POM in project)*

------
https://chatgpt.com/codex/tasks/task_e_68788d1c571083309b7298100561b261