### PR TITLE
Add sealed plugin base classes

### DIFF
--- a/svn_trunk/src/jd/plugins/AccountInvalidException.java
+++ b/svn_trunk/src/jd/plugins/AccountInvalidException.java
@@ -1,6 +1,6 @@
 package jd.plugins;
 
-public class AccountInvalidException extends PluginException {
+public final class AccountInvalidException extends PluginException {
 
     /**
      *

--- a/svn_trunk/src/jd/plugins/AccountRequiredException.java
+++ b/svn_trunk/src/jd/plugins/AccountRequiredException.java
@@ -1,6 +1,6 @@
 package jd.plugins;
 
-public class AccountRequiredException extends PluginException {
+public final class AccountRequiredException extends PluginException {
 
     /**
      *

--- a/svn_trunk/src/jd/plugins/AccountUnavailableException.java
+++ b/svn_trunk/src/jd/plugins/AccountUnavailableException.java
@@ -1,6 +1,6 @@
 package jd.plugins;
 
-public class AccountUnavailableException extends PluginException {
+public final class AccountUnavailableException extends PluginException {
 
     /**
      *

--- a/svn_trunk/src/jd/plugins/CaptchaException.java
+++ b/svn_trunk/src/jd/plugins/CaptchaException.java
@@ -4,7 +4,7 @@ import jd.controlling.captcha.SkipRequest;
 
 import org.jdownloader.captcha.blacklist.BlacklistEntry;
 
-public class CaptchaException extends PluginException {
+public final class CaptchaException extends PluginException {
     private final SkipRequest    skipRequest;
     private final BlacklistEntry blackListEntry;
 

--- a/svn_trunk/src/jd/plugins/CountryIPBlockException.java
+++ b/svn_trunk/src/jd/plugins/CountryIPBlockException.java
@@ -4,7 +4,7 @@ import jd.controlling.downloadcontroller.DownloadLinkCandidate;
 import jd.controlling.downloadcontroller.DownloadLinkCandidateResult;
 import jd.controlling.downloadcontroller.DownloadLinkCandidateResult.RESULT;
 
-public class CountryIPBlockException extends PluginException implements CandidateResultProvider {
+public final class CountryIPBlockException extends PluginException implements CandidateResultProvider {
     private String message;
 
     public CountryIPBlockException(String msg) {

--- a/svn_trunk/src/jd/plugins/MovePluginProgress.java
+++ b/svn_trunk/src/jd/plugins/MovePluginProgress.java
@@ -7,7 +7,7 @@ import org.jdownloader.images.AbstractIcon;
 import org.jdownloader.plugins.PluginTaskID;
 import org.jdownloader.translate._JDT;
 
-public class MovePluginProgress extends PluginProgress {
+public final class MovePluginProgress extends PluginProgress {
 
     private File   file;
     private String msg;

--- a/svn_trunk/src/jd/plugins/PluginException.java
+++ b/svn_trunk/src/jd/plugins/PluginException.java
@@ -17,7 +17,14 @@ package jd.plugins;
 
 import org.appwork.utils.StringUtils;
 
-public class PluginException extends Exception {
+public sealed class PluginException extends Exception
+    permits jd.plugins.AccountInvalidException,
+            jd.plugins.AccountRequiredException,
+            jd.plugins.AccountUnavailableException,
+            jd.plugins.CaptchaException,
+            jd.plugins.CountryIPBlockException,
+            jd.plugins.WrongPasswordException,
+            jd.plugins.hoster.DailyMotionComV2.NoAudioException {
     private static final long serialVersionUID              = -413339039711789194L;
     /* do not use final, as the compiler will replace Reference with value, no more Exceptions but broken ErrorHandling in stable */
     public static int         VALUE_ID_PREMIUM_TEMP_DISABLE = 0;

--- a/svn_trunk/src/jd/plugins/PluginProgress.java
+++ b/svn_trunk/src/jd/plugins/PluginProgress.java
@@ -22,7 +22,18 @@ import javax.swing.Icon;
 import org.jdownloader.gui.views.downloads.columns.ETAColumn;
 import org.jdownloader.plugins.PluginTaskID;
 
-public abstract class PluginProgress {
+public abstract sealed class PluginProgress
+    permits jd.plugins.MovePluginProgress,
+            org.jdownloader.captcha.v2.WaitForTrackerSlotPluginProcess,
+            org.jdownloader.controlling.ffmpeg.FFMpegInstallProgress,
+            org.jdownloader.controlling.ffmpeg.FFMpegProgress,
+            org.jdownloader.extensions.extraction.ExtractionProgress,
+            org.jdownloader.gui.views.components.packagetable.context.CheckStatusAction.LinkCheckProgress,
+            org.jdownloader.plugins.CaptchaStepProgress,
+            org.jdownloader.plugins.DownloadPluginProgress,
+            org.jdownloader.plugins.HashCheckPluginProgress,
+            org.jdownloader.plugins.SleepPluginProgress,
+            org.jdownloader.plugins.UserIOProgress {
     protected volatile long total                          = 0;
     protected volatile long current                        = 0;
     protected volatile long eta                            = -1;

--- a/svn_trunk/src/jd/plugins/WrongPasswordException.java
+++ b/svn_trunk/src/jd/plugins/WrongPasswordException.java
@@ -2,7 +2,7 @@ package jd.plugins;
 
 import org.jdownloader.translate._JDT;
 
-public class WrongPasswordException extends PluginException {
+public final class WrongPasswordException extends PluginException {
     /*
      * This is just an idea for the ability to add the type of password in order to have nicer UI translation such as
      * "Wrong folder password" or "Wrong decryption key".

--- a/svn_trunk/src/jd/plugins/hoster/DailyMotionComV2.java
+++ b/svn_trunk/src/jd/plugins/hoster/DailyMotionComV2.java
@@ -124,7 +124,7 @@ public class DailyMotionComV2 extends DailyMotionCom {
         return super.requestFileInformation(downloadLink);
     }
 
-    public class NoAudioException extends PluginException {
+    public final class NoAudioException extends PluginException {
         /**
          *
          */

--- a/svn_trunk/src/org/jdownloader/captcha/v2/WaitForTrackerSlotPluginProcess.java
+++ b/svn_trunk/src/org/jdownloader/captcha/v2/WaitForTrackerSlotPluginProcess.java
@@ -8,7 +8,7 @@ import org.jdownloader.translate._JDT;
 import jd.nutils.Formatter;
 import jd.plugins.PluginProgress;
 
-public class WaitForTrackerSlotPluginProcess extends PluginProgress {
+public final class WaitForTrackerSlotPluginProcess extends PluginProgress {
     /**
      *
      */

--- a/svn_trunk/src/org/jdownloader/controlling/ffmpeg/FFMpegInstallProgress.java
+++ b/svn_trunk/src/org/jdownloader/controlling/ffmpeg/FFMpegInstallProgress.java
@@ -10,7 +10,7 @@ import org.jdownloader.gui.views.downloads.columns.ETAColumn;
 import org.jdownloader.images.AbstractIcon;
 import org.jdownloader.plugins.PluginTaskID;
 
-public class FFMpegInstallProgress extends PluginProgress {
+public final class FFMpegInstallProgress extends PluginProgress {
     private String message;
 
     @Override

--- a/svn_trunk/src/org/jdownloader/controlling/ffmpeg/FFMpegProgress.java
+++ b/svn_trunk/src/org/jdownloader/controlling/ffmpeg/FFMpegProgress.java
@@ -11,7 +11,7 @@ import org.jdownloader.gui.views.downloads.columns.ProgressColumn;
 import org.jdownloader.images.AbstractIcon;
 import org.jdownloader.plugins.PluginTaskID;
 
-public class FFMpegProgress extends PluginProgress {
+public final class FFMpegProgress extends PluginProgress {
 
     public FFMpegProgress() {
         super(0, 100, null);

--- a/svn_trunk/src/org/jdownloader/extensions/extraction/ExtractionProgress.java
+++ b/svn_trunk/src/org/jdownloader/extensions/extraction/ExtractionProgress.java
@@ -14,7 +14,7 @@ import org.jdownloader.gui.views.downloads.columns.ProgressColumn;
 import org.jdownloader.images.NewTheme;
 import org.jdownloader.plugins.PluginTaskID;
 
-public class ExtractionProgress extends PluginProgress {
+public final class ExtractionProgress extends PluginProgress {
 
     protected long   lastCurrent    = -1;
     protected long   lastTotal      = -1;

--- a/svn_trunk/src/org/jdownloader/plugins/DownloadPluginProgress.java
+++ b/svn_trunk/src/org/jdownloader/plugins/DownloadPluginProgress.java
@@ -25,7 +25,7 @@ import org.jdownloader.images.AbstractIcon;
 import org.jdownloader.plugins.tasks.PluginProgressTask;
 import org.jdownloader.translate._JDT;
 
-public class DownloadPluginProgress extends PluginProgress {
+public final class DownloadPluginProgress extends PluginProgress {
     private final DownloadInterface downloadInterface;
     private final String            unknownFileSize = _JDT.T.gui_download_filesize_unknown() + " \u221E";
     protected final long            startTimeStamp;

--- a/svn_trunk/src/org/jdownloader/plugins/HashCheckPluginProgress.java
+++ b/svn_trunk/src/org/jdownloader/plugins/HashCheckPluginProgress.java
@@ -12,7 +12,7 @@ import org.jdownloader.gui.views.downloads.columns.ETAColumn;
 import org.jdownloader.images.AbstractIcon;
 import org.jdownloader.translate._JDT;
 
-public class HashCheckPluginProgress extends PluginProgress {
+public final class HashCheckPluginProgress extends PluginProgress {
     private final String message;
     private long         lastCurrent    = -1;
     private long         startTimeStamp = -1;

--- a/svn_trunk/src/org/jdownloader/plugins/SleepPluginProgress.java
+++ b/svn_trunk/src/org/jdownloader/plugins/SleepPluginProgress.java
@@ -8,7 +8,7 @@ import org.jdownloader.gui.IconKey;
 import org.jdownloader.images.AbstractIcon;
 import org.jdownloader.translate._JDT;
 
-public class SleepPluginProgress extends PluginProgress {
+public final class SleepPluginProgress extends PluginProgress {
     /**
      *
      */

--- a/svn_trunk/src/org/jdownloader/plugins/UserIOProgress.java
+++ b/svn_trunk/src/org/jdownloader/plugins/UserIOProgress.java
@@ -2,7 +2,7 @@ package org.jdownloader.plugins;
 
 import jd.plugins.PluginProgress;
 
-public class UserIOProgress extends PluginProgress {
+public final class UserIOProgress extends PluginProgress {
 
     private String message;
 


### PR DESCRIPTION
## Summary
- use sealed class for `PluginProgress` and list permitted subclasses
- seal `PluginException` and specify its derived exceptions
- mark subclasses as `final`

## Testing
- `javac -cp svn_trunk/src -d /tmp/classes svn_trunk/src/jd/plugins/PluginProgress.java` *(fails: package org.appwork.swing.exttable.columns does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68788d288988833090135a7be53a54c0